### PR TITLE
Fix DNS refresh by sending async request

### DIFF
--- a/VPN/vpnservice_support.go
+++ b/VPN/vpnservice_support.go
@@ -225,7 +225,7 @@ func (d *ProtectedDialer) Dial(ctx context.Context,
 		}
 
 		if time.Now().Sub(d.vServer.lastResolved) > time.Minute*30 {
-			d.PrepareDomain(Address, nil, d.preferIPv6)
+			go d.PrepareDomain(Address, nil, d.preferIPv6)
 		}
 
 		fd, err := d.getFd(dest.Network)


### PR DESCRIPTION
In a previous change, I made a mistake where the refresh DNS request will block the outgoing traffic. If user have DNS going through proxy, it will create a infinite loop. Fix it by changing the request to async.