### PR TITLE
Disable NDK Build ID

### DIFF
--- a/compile-tun2socks.sh
+++ b/compile-tun2socks.sh
@@ -32,7 +32,8 @@ $NDK_HOME/ndk-build \
 	APP_PLATFORM=android-19 \
 	NDK_LIBS_OUT=$TMPDIR/libs \
 	NDK_OUT=$TMPDIR/tmp \
-	APP_SHORT_COMMANDS=false LOCAL_SHORT_COMMANDS=false -B -j4
+	APP_SHORT_COMMANDS=false LOCAL_SHORT_COMMANDS=false -B -j4 \
+        LOCAL_LDFLAGS=-Wl,--build-id=none
 
 tar cvfz $__dir/libtun2socks.so.tgz libs
 popd


### PR DESCRIPTION
A temporary workaround for Reproducible Builds.

- https://f-droid.org/docs/Reproducible_Builds/#ndk-build-id

The NDK Build ID is for tracing and debugging. There's no impact on using when disabled.