### PR TITLE
Temporary Lock of qpack and quic-go in tidy.yml

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -59,6 +59,12 @@ jobs:
           # Lock gvisor version to a specific revision
           go mod edit -replace=gvisor.dev/gvisor=gvisor.dev/gvisor@v0.0.0-20231020174304-b8a429915ff1
 
+          # Lock qpack version to a specific revision
+          go mod edit -replace=github.com/quic-go/qpack=github.com/quic-go/qpack@v0.5.1
+
+          # Lock quic-go version to a specific revision
+          go mod edit -replace=github.com/quic-go/quic-go=github.com/quic-go/quic-go@v0.56.0
+
           # Lock grpc version to a specific revision
           go mod edit -replace=google.golang.org/grpc=google.golang.org/grpc@v1.66.3
 
@@ -90,7 +96,7 @@ jobs:
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/main.yml/dispatches \
             -d "{
-              \"ref\": \"main\",
+              \"ref\": \"master\",
               \"inputs\": {
                 \"release_tag\": \"${{ env.LATEST_TAG_NAME }}\"
               }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/jhump/protoreflect v1.17.0 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/reedsolomon v1.13.0 // indirect
 	github.com/lunixbochs/struc v0.0.0-20241101090106-8d528fa2c543 // indirect
@@ -49,8 +49,8 @@ require (
 	github.com/pion/transport/v4 v4.0.1 // indirect
 	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/quic-go/qpack v0.5.1 // indirect
-	github.com/quic-go/quic-go v0.56.0 // indirect
+	github.com/quic-go/qpack v0.6.0 // indirect
+	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 // indirect
 	github.com/rs/cors v1.11.1 // indirect
@@ -82,7 +82,7 @@ require (
 	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gvisor.dev/gvisor v0.0.0-20260115201132-a8b6e6a86515 // indirect
+	gvisor.dev/gvisor v0.0.0-20260117034648-554030c7ed7e // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 	nhooyr.io/websocket v1.8.17 // indirect
 )
@@ -90,3 +90,7 @@ require (
 replace google.golang.org/grpc => google.golang.org/grpc v1.66.3
 
 replace gvisor.dev/gvisor => gvisor.dev/gvisor v0.0.0-20231020174304-b8a429915ff1
+
+replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
+
+replace github.com/quic-go/quic-go => github.com/quic-go/quic-go v0.56.0

--- a/go.sum
+++ b/go.sum
@@ -1589,8 +1589,8 @@ github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
-github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=


### PR DESCRIPTION
## Temporary Lock of qpack and quic-go in tidy.yml

For now, **temporarily locking** specific versions of `qpack` and `quic-go` in the `tidy.yml` workflow from upstream updates.

### Locked references (commit 82f352143ba770403f1ed6169d13e44025397778)

- **qpack**  
https://github.com/2dust/AndroidLibV2rayLite/blob/82f352143ba770403f1ed6169d13e44025397778/.github/workflows/tidy.yml#L63

- **quic-go**  
https://github.com/2dust/AndroidLibV2rayLite/blob/82f352143ba770403f1ed6169d13e44025397778/.github/workflows/tidy.yml#L66

### Minimal fix
This line was updating dependencies (including qpack and quic-go):
https://github.com/2dust/AndroidLibV2rayLite/blob/1c0e2a89752764567cb2d46112ad4904efa62a5d/.github/workflows/tidy.yml#L69

I modified this section (~line 99):
https://github.com/2dust/AndroidLibV2rayLite/blob/82f352143ba770403f1ed6169d13e44025397778/.github/workflows/tidy.yml#L99
Automatically build the **master** branch whenever `tidy.yml` updates the Go module of v2ray-core.